### PR TITLE
feat(all): implement update channels support

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -3,9 +3,14 @@ map $http_user_agent $ver {
     "~^.*Update.*BPC\s+(\d+)\..*$" "v$1";
 }
 
-map $http_eset_spread_control $channel {
+map $http_eset_spread_control $raw_channel {
     default production;
     "~domain=(?P<d>[^;]+)" $d;
+}
+
+map "$ver:$raw_channel" $channel {
+    "ep6:pre-release" "production";
+    default $raw_channel;
 }
 
 log_format nod32 '[$time_local] remote_addr=$remote_addr remote_user=$remote_user request="$request" status=$status user_agent="$http_user_agent" ver=$ver channel=$channel';

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -29,33 +29,38 @@ server {
             # Versions: ep6 -> ep6.6
             # Rewrite logic:
             # ep6 => ep6.6
-            rewrite ^/(dll/)?update.ver$ /eset_upd/ep6.6/$channel/$1update.ver break;
+            rewrite ^/dll/update.ver$ /eset_upd/ep6.6/$channel/dll/update.ver break;
+            rewrite ^/update.ver$ /eset_upd/ep6.6/$channel/update.ver break;
         }
         if ($ver ~ "^ep[7-8]$") {
             # Versions: ep7 -> ep8
             # Rewrite logic:
             # ep7 => ep8
             # ep8 => ep8
-            rewrite ^/(dll/)?update.ver$ /eset_upd/ep8/$channel/$1update.ver break;
+            rewrite ^/dll/update.ver$ /eset_upd/ep8/$channel/dll/update.ver break;
+            rewrite ^/update.ver$ /eset_upd/ep8/$channel/update.ver break;
         }
         if ($ver ~ "^ep9$") {
             # Versions: ep9 -> ep9
             # Rewrite logic:
             # ep9 => ep9
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
+            rewrite ^/dll/update.ver$ /eset_upd/$ver/$channel/dll/update.ver break;
+            rewrite ^/update.ver$ /eset_upd/$ver/$channel/update.ver break;
         }
         if ($ver ~ "^ep1[0-1]$") {
             # Versions: ep10 -> ep11
             # Rewrite logic:
             # ep10 => ep10
             # ep11 => ep11
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
+            rewrite ^/dll/update.ver$ /eset_upd/$ver/$channel/dll/update.ver break;
+            rewrite ^/update.ver$ /eset_upd/$ver/$channel/update.ver break;
         }
         if ($ver ~ "^ep12$") {
             # Versions: ep12 -> ep12
             # Rewrite logic:
             # ep12 => ep12
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
+            rewrite ^/dll/update.ver$ /eset_upd/$ver/$channel/dll/update.ver break;
+            rewrite ^/update.ver$ /eset_upd/$ver/$channel/update.ver break;
         }
         if ($ver ~ "^v[3-9]$") {
             # Versions: v3 -> v9

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -8,6 +8,8 @@ map $http_eset_spread_control $channel {
     "~domain=(?P<d>[^;]+)" $d;
 }
 
+log_format nod32 '[$time_local] remote_addr=$remote_addr remote_user=$remote_user request="$request" status=$status user_agent="$http_user_agent" ver=$ver channel=$channel';
+
 server {
     server_name _;
     listen 80 default_server;
@@ -19,6 +21,8 @@ server {
 
     real_ip_header X-Real-IP;
     real_ip_recursive on;
+
+    access_log /var/log/nginx/access.log nod32;
 
     location ~* \.ver$ {
         if ($ver ~ "^ep6$") {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -25,6 +25,7 @@ server {
     index index.html index.htm;
 
     real_ip_header X-Real-IP;
+    set_real_ip_from 172.16.0.0/12;
     real_ip_recursive on;
 
     access_log /var/log/nginx/access.log nod32;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -69,16 +69,11 @@ server {
             # v13 => v10
             rewrite ^(.*) /eset_upd/v10/update.ver break;
         }
-        if ($ver ~ "^v1[4-5]$") {
-            # Versions: v14 -> v15
+        if ($ver ~ "^v1[4-8]$") {
+            # Versions: v14 -> v18
             # Rewrite logic:
-            # v14 => v14
-            # v15 => v15
-            rewrite ^(.*) /eset_upd/$ver/dll/update.ver break;
-        }
-        if ($ver ~ "^v1[6-8]$") {
-            # Versions: v16 -> v18
-            # Rewrite logic:
+            # v14 => v16
+            # v15 => v16
             # v16 => v16
             # v17 => v16
             # v18 => v18

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -3,6 +3,11 @@ map $http_user_agent $ver {
     "~^.*Update.*BPC\s+(\d+)\..*$" "v$1";
 }
 
+map $http_eset_spread_control $channel {
+    default production;
+    "~domain=(?P<d>[^;]+)" $d;
+}
+
 server {
     server_name _;
     listen 80 default_server;
@@ -20,33 +25,33 @@ server {
             # Versions: ep6 -> ep6.6
             # Rewrite logic:
             # ep6 => ep6.6
-            rewrite ^/(dll/)?update.ver$ /eset_upd/ep6.6/$1update.ver break;
+            rewrite ^/(dll/)?update.ver$ /eset_upd/ep6.6/$channel/$1update.ver break;
         }
         if ($ver ~ "^ep[7-8]$") {
             # Versions: ep7 -> ep8
             # Rewrite logic:
             # ep7 => ep8
             # ep8 => ep8
-            rewrite ^/(dll/)?update.ver$ /eset_upd/ep8/$1update.ver break;
+            rewrite ^/(dll/)?update.ver$ /eset_upd/ep8/$channel/$1update.ver break;
         }
         if ($ver ~ "^ep9$") {
             # Versions: ep9 -> ep9
             # Rewrite logic:
             # ep9 => ep9
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$1update.ver break;
+            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
         }
         if ($ver ~ "^ep1[0-1]$") {
             # Versions: ep10 -> ep11
             # Rewrite logic:
             # ep10 => ep10
             # ep11 => ep11
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$1update.ver break;
+            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
         }
         if ($ver ~ "^ep12$") {
             # Versions: ep12 -> ep12
             # Rewrite logic:
             # ep12 => ep12
-            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$1update.ver break;
+            rewrite ^/(dll/)?update.ver$ /eset_upd/$ver/$channel/$1update.ver break;
         }
         if ($ver ~ "^v[3-9]$") {
             # Versions: v3 -> v9
@@ -58,7 +63,7 @@ server {
             # v7 => v3
             # v8 => v3
             # v9 => v3
-            rewrite ^(.*) /eset_upd/v3/update.ver break;
+            rewrite ^(.*) /eset_upd/v3/$channel/update.ver break;
         }
         if ($ver ~ "^v1[0-3]$") {
             # Versions: v10 -> v13
@@ -67,7 +72,7 @@ server {
             # v11 => v10
             # v12 => v10
             # v13 => v10
-            rewrite ^(.*) /eset_upd/v10/update.ver break;
+            rewrite ^(.*) /eset_upd/v10/$channel/update.ver break;
         }
         if ($ver ~ "^v1[4-8]$") {
             # Versions: v14 -> v18
@@ -77,7 +82,7 @@ server {
             # v16 => v16
             # v17 => v16
             # v18 => v18
-            rewrite ^(.*) /eset_upd/v16/dll/update.ver break;
+            rewrite ^(.*) /eset_upd/v16/$channel/dll/update.ver break;
         }
     }
 }

--- a/nod32ms.conf
+++ b/nod32ms.conf
@@ -243,14 +243,6 @@ platforms = ""
 mirror = 1
 platforms = ""
 
-[ESET.VERSIONS.v14]
-mirror = 1
-platforms = ""
-
-[ESET.VERSIONS.v15]
-mirror = 1
-platforms = ""
-
 [ESET.VERSIONS.v16]
 mirror = 1
 platforms = ""

--- a/nod32ms.conf
+++ b/nod32ms.conf
@@ -205,6 +205,7 @@ mirror = "update.eset.com, um01.eset.com, um02.eset.com, um03.eset.com, um04.ese
 [ESET.VERSIONS]
 ; Global fallback settings (used if not specified for specific versions)
 platforms = ""
+channels = ""
 
 ; Version-specific settings using dot notation
 ; Format: [ESET.VERSIONS.<version>]
@@ -214,35 +215,44 @@ platforms = ""
 [ESET.VERSIONS.ep6]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.ep8]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.ep9]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.ep10]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.ep11]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.ep12]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.v3]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.v10]
 mirror = 1
 platforms = ""
+channels = ""
 
 [ESET.VERSIONS.v16]
 mirror = 1
 platforms = ""
+channels = ""

--- a/tools/index.html
+++ b/tools/index.html
@@ -153,6 +153,7 @@
       padding: 18px 24px;
       font-size: 0.95rem;
       border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+      vertical-align: top;
     }
 
     th {
@@ -169,6 +170,22 @@
     tbody tr:hover {
       background: rgba(56, 189, 248, 0.06);
     }
+
+    .channel-badge {
+      display: inline-flex;
+      padding: 2px 8px;
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border: 1px solid currentColor;
+    }
+    .channel-production { color: #22c55e; background: rgba(34, 197, 94, 0.1); border-color: rgba(34, 197, 94, 0.3); }
+    .channel-deferred { color: #f59e0b; background: rgba(245, 158, 11, 0.1); border-color: rgba(245, 158, 11, 0.3); }
+    .channel-pre-release { color: #8b5cf6; background: rgba(139, 92, 246, 0.1); border-color: rgba(139, 92, 246, 0.3); }
+    .channel-default { color: var(--text-muted); background: rgba(148, 163, 184, 0.1); border-color: rgba(148, 163, 184, 0.3); }
+
 
     .platform-badges {
       display: flex;
@@ -219,6 +236,7 @@
       gap: 12px;
       align-items: center;
       font-size: 0.9rem;
+      flex-wrap: wrap;
     }
 
     .files a {
@@ -387,7 +405,7 @@
 
   <section class="table-card">
     <header>
-      <h2>Версии и платформы</h2>
+      <h2>Версии и каналы</h2>
       <span class="badge" id="table-badge">—</span>
     </header>
     <div class="table-wrapper">
@@ -395,9 +413,9 @@
         <thead>
           <tr>
             <th>Версия</th>
+            <th>Канал</th>
             <th>Платформы</th>
             <th>База</th>
-            <th>Размер базы</th>
             <th>Файлы</th>
             <th>Обновлено</th>
           </tr>
@@ -487,7 +505,21 @@
     return wrap;
   }
 
-  function createFileLinks(versionKey, files) {
+  function createChannelBadge(channel) {
+    const b = document.createElement('span');
+    b.className = `channel-badge channel-${channel.toLowerCase()}`;
+    b.textContent = channel;
+    // fallback for unknown channels
+    if (!b.classList.contains('channel-production') &&
+        !b.classList.contains('channel-deferred') &&
+        !b.classList.contains('channel-pre-release') &&
+        !b.classList.contains('channel-default')) {
+        b.classList.add('channel-default');
+    }
+    return b;
+  }
+
+  function createFileLinks(versionKey, channelName, files) {
     const { file, dll } = files || {};
     const div = document.createElement('div');
     div.className = 'files';
@@ -497,7 +529,7 @@
       a.href = file;
       a.target = '_blank';
       a.rel = 'noopener';
-      a.title = `update.ver для ${versionKey}`;
+      a.title = `update.ver для ${versionKey} (${channelName})`;
       a.textContent = 'Файл';
       parts.push(a);
     }
@@ -506,7 +538,7 @@
       a.href = dll;
       a.target = '_blank';
       a.rel = 'noopener';
-      a.title = `dll/update.ver для ${versionKey}`;
+      a.title = `dll/update.ver для ${versionKey} (${channelName})`;
       a.textContent = 'DLL';
       parts.push(a);
     }
@@ -594,54 +626,83 @@
     const frag = document.createDocumentFragment();
 
     for (const [key, data] of entries) {
-      const tr = document.createElement('tr');
+      const channels = data.channels || { default: { database_version: data.database?.version, files: data.files } };
+      const channelEntries = Object.entries(channels);
 
-      const tdVer = document.createElement('td');
-      tdVer.setAttribute('data-label', 'Версия');
-      tdVer.innerHTML = `
-        <div style="display:flex; flex-direction:column; gap:6px;">
-          <strong></strong>
-          <small style="color:var(--text-muted); font-size:0.8rem;"></small>
-        </div>
-      `;
-      tdVer.querySelector('strong').textContent = data?.name || key;
-      tdVer.querySelector('small').textContent = String(key).toUpperCase();
+      channelEntries.forEach(([channelName, channelData], index) => {
+          const tr = document.createElement('tr');
 
-      const tdPlat = document.createElement('td');
-      tdPlat.setAttribute('data-label', 'Платформы');
-      tdPlat.appendChild(createPlatformBadges(data?.platforms));
+          // Version column (only for first channel row, spans multiple rows if needed)
+          if (index === 0) {
+              const tdVer = document.createElement('td');
+              tdVer.setAttribute('data-label', 'Версия');
+              if (channelEntries.length > 1) {
+                  tdVer.rowSpan = channelEntries.length;
+              }
+              tdVer.innerHTML = `
+                <div style="display:flex; flex-direction:column; gap:6px;">
+                  <strong></strong>
+                  <small style="color:var(--text-muted); font-size:0.8rem;"></small>
+                </div>
+                <div style="margin-top:8px;"></div>
+              `;
+              tdVer.querySelector('strong').textContent = data?.name || key;
+              tdVer.querySelector('small').textContent = String(key).toUpperCase();
 
-      const tdDb = document.createElement('td');
-      tdDb.setAttribute('data-label', 'База');
-      tdDb.innerHTML = `
-        <div style="display:flex; flex-direction:column; gap:4px;">
-          <span style="font-weight:600; font-size:1rem;"></span>
-          <small style="color:var(--text-muted); font-size:0.8rem;">Version ID</small>
-        </div>
-      `;
-      tdDb.querySelector('span').textContent = data?.database?.version ?? '—';
+              // Add size info to version cell as it applies to the whole version
+              const sizeContainer = buildSizeCell(data?.database?.size?.bytes);
+              tdVer.querySelector('div:last-child').appendChild(sizeContainer);
 
-      const tdSize = document.createElement('td');
-      tdSize.setAttribute('data-label', 'Размер базы');
-      tdSize.appendChild(buildSizeCell(data?.database?.size?.bytes));
+              tr.appendChild(tdVer);
+          }
 
-      const tdFiles = document.createElement('td');
-      tdFiles.setAttribute('data-label', 'Файлы');
-      tdFiles.appendChild(createFileLinks(key, data?.files));
+          // Channel column
+          const tdChannel = document.createElement('td');
+          tdChannel.setAttribute('data-label', 'Канал');
+          tdChannel.appendChild(createChannelBadge(channelName));
+          tr.appendChild(tdChannel);
 
-      const tdTime = document.createElement('td');
-      tdTime.className = 'timestamp';
-      tdTime.setAttribute('data-label', 'Обновлено');
-      const abs = document.createElement('span');
-      abs.textContent = formatAbsolute(data?.database?.last_update);
-      const rel = document.createElement('small');
-      rel.textContent = formatRelative(data?.database?.last_update);
-      tdTime.appendChild(abs);
-      tdTime.appendChild(rel);
-      tdTime.setAttribute('data-iso-updated', data?.database?.last_update || '');
+          // Platforms (taken from main version info, as they are likely same)
+          const tdPlat = document.createElement('td');
+          tdPlat.setAttribute('data-label', 'Платформы');
+          tdPlat.appendChild(createPlatformBadges(data?.platforms));
+          tr.appendChild(tdPlat);
 
-      tr.append(tdVer, tdPlat, tdDb, tdSize, tdFiles, tdTime);
-      frag.appendChild(tr);
+          // Database Version
+          const tdDb = document.createElement('td');
+          tdDb.setAttribute('data-label', 'База');
+          tdDb.innerHTML = `
+            <div style="display:flex; flex-direction:column; gap:4px;">
+              <span style="font-weight:600; font-size:1rem;"></span>
+              <small style="color:var(--text-muted); font-size:0.8rem;">Version ID</small>
+            </div>
+          `;
+          tdDb.querySelector('span').textContent = channelData?.database_version ?? '—';
+          tr.appendChild(tdDb);
+
+          // Files
+          const tdFiles = document.createElement('td');
+          tdFiles.setAttribute('data-label', 'Файлы');
+          tdFiles.appendChild(createFileLinks(key, channelName, channelData?.files));
+          tr.appendChild(tdFiles);
+
+          // Updated Time (using main version update time as fallback)
+          const tdTime = document.createElement('td');
+          tdTime.className = 'timestamp';
+          tdTime.setAttribute('data-label', 'Обновлено');
+
+          const updateTime = data?.database?.last_update;
+          const abs = document.createElement('span');
+          abs.textContent = formatAbsolute(updateTime);
+          const rel = document.createElement('small');
+          rel.textContent = formatRelative(updateTime);
+          tdTime.appendChild(abs);
+          tdTime.appendChild(rel);
+          tdTime.setAttribute('data-iso-updated', updateTime || '');
+          tr.appendChild(tdTime);
+
+          frag.appendChild(tr);
+      });
     }
 
     body.replaceChildren(frag);

--- a/worker/core/inc/classes/VersionConfig.class.php
+++ b/worker/core/inc/classes/VersionConfig.class.php
@@ -71,6 +71,43 @@ class VersionConfig
     }
 
     /**
+     * Get channels for version
+     * @param string $version
+     * @return array|bool
+     */
+    public static function get_version_channels($version)
+    {
+        // First check version-specific config
+        $version_config = self::get_version_config($version);
+        if ($version_config && isset($version_config['channels'])) {
+            $channels = $version_config['channels'];
+
+            // If channels is empty, true, or null, return all channels
+            if (empty($channels) || $channels === true || $channels === null) {
+                return true;
+            }
+
+            return Tools::parse_comma_list($channels);
+        }
+
+        // If no version-specific config, check global config
+        $global_config = Config::get('ESET.VERSIONS');
+        if ($global_config && isset($global_config['channels'])) {
+            $channels = $global_config['channels'];
+
+            // If channels is empty, true, or null, return all channels
+            if (empty($channels) || $channels === true || $channels === null) {
+                return true;
+            }
+
+            return Tools::parse_comma_list($channels);
+        }
+
+        // No channels specified anywhere - download all available channels
+        return true;
+    }
+
+    /**
      * Get all enabled versions
      * @return array
      */

--- a/worker/core/inc/init.php
+++ b/worker/core/inc/init.php
@@ -112,8 +112,8 @@ $DIRECTORIES = [
                 'dll' => false
             ],
             'deferred' => [
-                'file' => false,
-                'dll' => 'deferred/eset_upd/update.ver'
+                'file' => 'deferred/eset_upd/update.ver',
+                'dll' => false
             ]
         ]
     ],

--- a/worker/core/inc/init.php
+++ b/worker/core/inc/init.php
@@ -128,6 +128,7 @@ $DIRECTORIES = [
                 'file' => 'eset_upd/v10/pre/update.ver',
                 'dll' => false
             ]
+        ]
     ],
     'v16' => [
         'name' => 'ESET NOD32 14-19',

--- a/worker/core/inc/init.php
+++ b/worker/core/inc/init.php
@@ -67,18 +67,8 @@ $DIRECTORIES = [
         'file' => 'eset_upd/v10/update.ver',
         'dll' => false
     ],
-    'v14' => [
-        'name' => 'ESET NOD32 14',
-        'file' => false,
-        'dll' => 'eset_upd/v14/dll/update.ver'
-    ],
-    'v15' => [
-        'name' => 'ESET NOD32 15',
-        'file' => false,
-        'dll' => 'eset_upd/v15/dll/update.ver'
-    ],
     'v16' => [
-        'name' => 'ESET NOD32 16-18',
+        'name' => 'ESET NOD32 14-18',
         'file' => false,
         'dll' => 'eset_upd/v16/dll/update.ver'
     ]

--- a/worker/core/inc/init.php
+++ b/worker/core/inc/init.php
@@ -29,47 +29,117 @@ spl_autoload_register($autoload);
 $DIRECTORIES = [
     'ep6' => [
         'name' => 'ESET NOD32 Endpoint 6',
-        'file' => 'eset_upd/ep6.6/update.ver',
-        'dll' => 'eset_upd/ep6.6/dll/update.ver'
+        'channels' => [
+            'production' => [
+                'file' => 'eset_upd/ep6.6/update.ver',
+                'dll' => 'eset_upd/ep6.6/dll/update.ver'
+            ],
+            'deferred' => [
+                'file' => 'deferred/eset_upd/ep6.6/update.ver',
+                'dll' => 'deferred/eset_upd/ep6.6/dll/update.ver'
+            ]
+        ]
     ],
     'ep8' => [
         'name' => 'ESET NOD32 Endpoint 7-8',
-        'file' => 'eset_upd/ep8/update.ver',
-        'dll' => 'eset_upd/ep8/dll/update.ver'
+        'channels' => [
+            'production' => [
+                'file' => 'eset_upd/ep8/update.ver',
+                'dll' => 'eset_upd/ep8/dll/update.ver'
+            ],
+            'deferred' => [
+                'file' => 'deferred/eset_upd/ep8/update.ver',
+                'dll' => 'deferred/eset_upd/ep8/dll/update.ver'
+            ]
+        ]
     ],
     'ep9' => [
         'name' => 'ESET NOD32 Endpoint 9',
-        'file' => 'eset_upd/ep9/update.ver',
-        'dll' => 'eset_upd/ep9/dll/update.ver'
+        'channels' => [
+            'production' => [
+                'file' => 'eset_upd/ep9/update.ver',
+                'dll' => 'eset_upd/ep9/dll/update.ver'
+            ],
+            'deferred' => [
+                'file' => 'deferred/eset_upd/ep9/update.ver',
+                'dll' => 'deferred/eset_upd/ep9/dll/update.ver'
+            ],
+            'pre-release' => [
+                'file' => 'eset_upd/ep9/pre/update.ver',
+                'dll' => 'eset_upd/ep9/pre/dll/update.ver'
+            ]
+        ]
     ],
     'ep10' => [
-        'name' => 'ESET NOD32 Endpoint 10',
-        'file' => false,
-        'dll' => 'eset_upd/ep10/dll/update.ver'
-    ],
-    'ep11' => [
-        'name' => 'ESET NOD32 Endpoint 11',
-        'file' => false,
-        'dll' => 'eset_upd/ep11/dll/update.ver'
+        'name' => 'ESET NOD32 Endpoint 10-11',
+        'channels' => [
+            'production' => [
+                'file' => false,
+                'dll' => 'eset_upd/ep10/dll/update.ver'
+            ],
+            'deferred' => [
+                'file' => false,
+                'dll' => 'deferred/eset_upd/ep10/dll/update.ver'
+            ],
+            'pre-release' => [
+                'file' => false,
+                'dll' => 'eset_upd/ep10/pre/dll/update.ver'
+            ]
+        ]
     ],
     'ep12' => [
         'name' => 'ESET NOD32 Endpoint 12',
-        'file' => false,
-        'dll' => 'eset_upd/ep12/dll/update.ver'
+        'channels' => [
+            'production' => [
+                'file' => false,
+                'dll' => 'eset_upd/ep12/dll/update.ver'
+            ],
+            'deferred' => [
+                'file' => false,
+                'dll' => 'deferred/eset_upd/ep12/dll/update.ver'
+            ],
+            'pre-release' => [
+                'file' => false,
+                'dll' => 'eset_upd/ep12/pre/dll/update.ver'
+            ]
+        ]
     ],
     'v3' => [
         'name' => 'ESET NOD32 3-9',
-        'file' => 'eset_upd/update.ver',
-        'dll' => false
+        'channels' => [
+            'production' => [
+                'file' => 'eset_upd/update.ver',
+                'dll' => false
+            ],
+            'deferred' => [
+                'file' => false,
+                'dll' => 'deferred/eset_upd/update.ver'
+            ]
+        ]
     ],
     'v10' => [
         'name' => 'ESET NOD32 10-13',
-        'file' => 'eset_upd/v10/update.ver',
-        'dll' => false
+        'channels' => [
+            'production' => [
+                'file' => 'eset_upd/v10/update.ver',
+                'dll' => false
+            ],
+            'pre-release' => [
+                'file' => 'eset_upd/v10/pre/update.ver',
+                'dll' => false
+            ]
     ],
     'v16' => [
-        'name' => 'ESET NOD32 14-18',
-        'file' => false,
-        'dll' => 'eset_upd/v16/dll/update.ver'
+        'name' => 'ESET NOD32 14-19',
+        'channels' => [
+            'production' => [
+                'file' => false,
+                'dll' => 'eset_upd/v16/dll/update.ver'
+            ],
+            'pre-release' => [
+                'file' => false,
+                'dll' => 'eset_upd/v16/pre/dll/update.ver'
+            ]
+        ]
     ]
 ];


### PR DESCRIPTION
Major architectural update to support multiple update channels (production, deferred, pre-release) for each ESET product version.

Key changes:
- worker:
  - Updated `Mirror` class to handle nested channel structure in configuration.
  - Implemented correct local path construction using `Tools::ds()` for cross-platform compatibility.
  - Updated `Nod32ms` to generate `index.json` with detailed channel information.
  - Improved `index.html` generation logic to handle missing files and prioritize production channel data.
  - Fixed logic for finding best available `update.ver` file when 'file' variant is missing (fallback to 'dll').
  - Updated `init.php` configuration structure to include channel definitions for all versions.

- nginx:
  - Added extraction of channel from `Eset-Spread-Control` header.
  - Updated rewrite rules to route requests to channel-specific subdirectories.
  - Implemented channel override logic via map: force 'production' channel for 'ep6' version even if 'pre-release' is requested.
  - Refactored rewrite rules to avoid capturing group conflicts with variables.

- tools:
  - Updated interactive `index.html` to display detailed breakdown of versions by channel.
  - Added visual badges for different channel types.

- config:
  - Added `channels` option to `nod32ms.conf` for version-specific channel filtering.